### PR TITLE
Timer QA Fix

### DIFF
--- a/gaak/gaak/ViewController/CameraViewControllerExtension.swift
+++ b/gaak/gaak/ViewController/CameraViewControllerExtension.swift
@@ -249,9 +249,11 @@ extension CameraViewController {
         case 2:
             setTime = 5
             timerButton.setImage(UIImage(named: "timer5"), for: .normal)
+            timeLeft.isHidden = false
         case 3:
             setTime = 10
             timerButton.setImage(UIImage(named: "timer10"), for: .normal)
+            timeLeft.isHidden = false
             
         default:
             break
@@ -287,6 +289,7 @@ extension CameraViewController {
 
                     timer.invalidate()
                     self.capturePhoto()
+                    self.timeLeft.isHidden = true
                 }
             }
         } else {

--- a/gaak/gaak/ViewController/CameraViewControllerExtension.swift
+++ b/gaak/gaak/ViewController/CameraViewControllerExtension.swift
@@ -246,14 +246,17 @@ extension CameraViewController {
             setTime = 3
             timerButton.setImage(UIImage(named: "timer3"), for: .normal)
             timeLeft.isHidden = false
+            timeLeft.text = String(setTime)
         case 2:
             setTime = 5
             timerButton.setImage(UIImage(named: "timer5"), for: .normal)
             timeLeft.isHidden = false
+            timeLeft.text = String(setTime)
         case 3:
             setTime = 10
             timerButton.setImage(UIImage(named: "timer10"), for: .normal)
             timeLeft.isHidden = false
+            timeLeft.text = String(setTime)
             
         default:
             break
@@ -278,7 +281,6 @@ extension CameraViewController {
         
         if (timerStatus != 0) {
             var countDown = setTime + 2
-
             Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
 
                 countDown -= 1


### PR DESCRIPTION
1. 각각 타이머를 터치했을대, 설정된 시간이 화면에 표시 되도록함. (3초, 5초, 10초)
2. 촬영 완료 후 0초가 화면에서 사라지도록함..
3. 타이머 촬영을 마친 후, 다시 재촬영 선택시 화면에 설정된 시간이 표시 되도록함. (3초, 5초, 10초)

#51 